### PR TITLE
Ability to provide args to desktop version

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -17,6 +17,9 @@ task run(dependsOn: classes, type: JavaExec) {
     
     if(Os.isFamily(Os.FAMILY_MAC))
         jvmArgs += "-XstartOnFirstThread"
+
+    if(project.hasProperty('args'))
+        args project.args.split(',')
 }
 
 task debug(dependsOn: classes, type: JavaExec) {

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -19,7 +19,7 @@ task run(dependsOn: classes, type: JavaExec) {
         jvmArgs += "-XstartOnFirstThread"
 
     if(project.hasProperty('args'))
-        args project.args.split(',')
+        args project.args.split(' ')
 }
 
 task debug(dependsOn: classes, type: JavaExec) {


### PR DESCRIPTION
I couldn't find a way to pass arguments from IDE and all my searches led to this solution
Example arguments I tested on Android Studio run configuration Arguments field
~~`-Pargs=-home,'C:/Games/Blizzard/Diablo II',-i,1920,-o,1080`~~
Updated: `-Pargs='-home "E:/Games/Diablo II" -i 1920 -o 1080'`
Feel free to close this PR if there is already a way to provide args to desktop version.